### PR TITLE
Fixes rendering on GitHub

### DIFF
--- a/public/change-events-profile.md
+++ b/public/change-events-profile.md
@@ -43,6 +43,7 @@ Change events can be retrieved with a simple REST call using the /changes suffix
 ```
 /equipment/changes
 ```
+
 ```javascript
 {
     "equipment_changes": [
@@ -109,6 +110,7 @@ As demonstrated below, it's sufficient to append a /stream suffix to get back a 
 ```
 /equipment/changes/stream
 ```
+
 ```
 "event": "equipment_insert",
 "id": "6113607438701690883",
@@ -131,7 +133,6 @@ Out-of-the-box server libraries are available on various platforms : e.g. [Node]
 On the browser side EventSource is a standard HTML5 element, with [polyfills](http://html5please.com/#eventSource) available for dated browsers
 
 
-
 ## Filtering
 
 Simple Filtering may be applied to change events, either when requesting or streaming change events
@@ -139,6 +140,3 @@ Simple Filtering may be applied to change events, either when requesting or stre
 ```
 /canAlerts/changes/stream?equipment=...
 ```
-
-
-

--- a/public/change-events-profile.md
+++ b/public/change-events-profile.md
@@ -82,7 +82,8 @@ Change events can be retrieved with a simple REST call using the /changes suffix
             }
         }
     ]
-}```
+}
+```
 
 ### Paging
 


### PR DESCRIPTION
This PR fixes the rendering of the `Change Events Profile` documentation so it is better rendered by GitHub.

The changes can be viewed [rendered](https://github.com/bltavares/agco-json-api-profiles/blob/fixes-rendering-on-github/public/change-events-profile.md)

Screenshot of before:
<img width="1280" alt="screen shot 2016-05-16 at 2 33 11 pm" src="https://cloud.githubusercontent.com/assets/109474/15297963/61db1b40-1b73-11e6-8183-feb5232ee991.png">

Screenshot after:
<img width="1280" alt="screen shot 2016-05-16 at 2 33 28 pm" src="https://cloud.githubusercontent.com/assets/109474/15297991/7bc9814a-1b73-11e6-8438-1c56b936767e.png">
